### PR TITLE
Added Dockerfile specific to the master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7-alpine
+
+RUN apk add --no-cache --virtual .build-deps gcc libc-dev libxslt-dev && \
+    apk add --no-cache libxslt && \
+    pip install --no-cache-dir lxml && \
+    apk del .build-deps && \
+    apk add git && \
+    git clone --single-branch --branch master https://github.com/lanmaster53/recon-ng.git /root/recon-ng
+
+WORKDIR /root/recon-ng
+
+RUN pip install -r REQUIREMENTS
+
+CMD ./recon-ng


### PR DESCRIPTION
Note: This Dockerfile will only work with the master branch. 

To build the Docker image:
docker build -t recon-ng .

To run recon-ng:
(First ensure that the ~/.recon-ng directory exists on your host.)
docker run --rm -it -v ~/.recon-ng:/root/.recon-ng recon-ng

To run recon-web:
docker run --rm -it -v ~/.recon-ng:/root/.recon-ng --entrypoint "./recon-web" -p 5000:5000 recon-ng --host 0.0.0.0

To run recon-cli:
docker run --rm -it -v ~/.recon-ng:/root/.recon-ng --entrypoint "./recon-cli" recon-ng <command>