### PR TITLE
Trim whitespace to make a valid IP

### DIFF
--- a/recon/core/module.py
+++ b/recon/core/module.py
@@ -111,7 +111,7 @@ class BaseModule(framework.Framework):
 
     def cidr_to_list(self, string):
         import ipaddress
-        return [str(ip) for ip in ipaddress.ip_network(string)]
+        return [str(ip).strip() for ip in ipaddress.ip_network(string)]
 
     def hosts_to_domains(self, hosts, exclusions=[]):
         domains = []


### PR DESCRIPTION
I kept getting the error when running modules on a netblock: 

[!] '1.2.3.4/29 ' does not appear to be an IPv4 or IPv6 network.

Note the trailing space. This would happen even when I manually inserted the CIDR and made sure there was no space. Not sure where/why the space was being added, so this PR removes trailing spaces.