### PR TITLE
Added CORS support for web API

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -7,6 +7,7 @@ requests
 # web
 flask
 flask-restful
+flask-cors
 flasgger
 dicttoxml
 XlsxWriter

--- a/recon-web
+++ b/recon-web
@@ -6,9 +6,10 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--host', default='127.0.0.1', help="IP address to listen on")
 parser.add_argument('--port', default=5000, help="port to bind the web server to")
+parser.add_argument('--origin', default='*', help="origin to restrict Cross-Origin Resource Sharing (CORS) for it only (default policy is '*' for '/api/*')")
 
 args = parser.parse_args()
 
-app = create_app()
+app = create_app(cors_origin=args.origin)
 if __name__ == '__main__':
     app.run(host=args.host, port=args.port)

--- a/recon/core/web/__init__.py
+++ b/recon/core/web/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask, cli, render_template
+from flask_cors import CORS
 from flasgger import Swagger
 from recon.core import base
 from recon.core.constants import BANNER_WEB
@@ -35,12 +36,13 @@ SWAGGER = {
 WORKSPACE = recon.workspace.split('/')[-1]
 print((f" * Workspace initialized: {WORKSPACE}"))
 
-def create_app():
+def create_app(cors_origin='*'):
 
     # setting the static_url_path to blank serves static files from the web root
     app = Flask(__name__, static_url_path='')
     app.config.from_object(__name__)
 
+    CORS(app, resources={r"^/api/*": {"origins": cors_origin}})
     Swagger(app, template_file='definitions.yaml')
 
     app.redis = Redis.from_url(app.config['REDIS_URL'])


### PR DESCRIPTION
#94 

Added CORS support for web API :
- the default policy is '\*' for '/api/*'
- an optional argument '--origin' is added to restrict the CORS to one origin
