### PR TITLE
Support synchronous running of modules and locking for concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *sublime*
 venv/
 scripts/
+.idea

--- a/recon/core/framework.py
+++ b/recon/core/framework.py
@@ -117,6 +117,7 @@ class Framework(cmd.Cmd):
     _record = None
     _spool = None
     _summary_counts = {}
+    _inserted_data = {}
 
     def __init__(self, params):
         cmd.Cmd.__init__(self)
@@ -636,6 +637,11 @@ class Framework(cmd.Cmd):
         else:
             query = f"INSERT INTO `{table}` (`{columns_str}`) SELECT {placeholder_str} WHERE NOT EXISTS(SELECT * FROM `{table}` WHERE {unique_columns_str})"
         values = tuple([data[column] for column in columns] + [data[column] for column in unique_columns])
+
+        # record data for inclusion in task info
+        if table not in self._inserted_data:
+            self._inserted_data[table] = []
+        self._inserted_data[table].append(data)
 
         # query the database
         rowcount = self.query(query, values)

--- a/recon/core/module.py
+++ b/recon/core/module.py
@@ -328,6 +328,7 @@ class BaseModule(framework.Framework):
         self._validate_options()
         self._validate_input()
         self._summary_counts = {}
+        self._inserted_data = {}
         pre = self.module_pre()
         params = [pre] if pre is not None else []
         # provide input if a default query is specified in the module

--- a/recon/core/tasks.py
+++ b/recon/core/tasks.py
@@ -1,12 +1,15 @@
 from recon.core import base
 from recon.core.web.db import Tasks
 from rq import get_current_job
+from threading import Lock
 import traceback
 
 # These tasks exist outside the web directory to avoid loading the entire 
 # application (which reloads the framework) on every task execution.
 
-def run_module(workspace, module):
+execution_locks = {}
+
+def run_module_async(workspace, module, options=None):
 
     results = {}
     try:
@@ -19,7 +22,8 @@ def run_module(workspace, module):
         tasks.update_task(job.get_id(), status=job.get_status())
         # execute the task
         module = recon._loaded_modules.get(module)
-        module.run()
+        run_module_with_lock(module, options)
+
     except Exception as e:
         results['error'] = {
             'type': str(type(e)),
@@ -27,6 +31,33 @@ def run_module(workspace, module):
             'traceback': traceback.format_exc(),
         }
     results['summary'] = module._summary_counts
+    results['data'] = module._inserted_data
     # update the task's status and results
     tasks.update_task(job.get_id(), status='finished', result=results)
     return results
+
+def run_module_sync(workspace, module_path, options=None):
+    recon = base.Recon(check=False, analytics=False, marketplace=False)
+    recon.start(base.Mode.JOB, workspace=workspace)
+    module = recon._loaded_modules.get(module_path)
+    run_module_with_lock(module, options)
+    return {
+        'summary': module._summary_counts,
+        'data': module._inserted_data
+    }
+
+
+def run_module_with_lock(module, options=None):
+    if module._modulename not in execution_locks:
+        execution_locks[module._modulename] = Lock()
+
+    with execution_locks[module._modulename]:
+        if options is not None:
+            original_options = module.options.copy()
+            module.options.update(options)
+
+        try:
+            module.run()
+        finally:
+            if options is not None:
+                module.options.update(original_options)


### PR DESCRIPTION
- Supports the `sync` query parameter for the `POST /api/task/` endpoint so results can be returned as part of the request.
- Add data to task info (should the `result_ttl` for tasks be configurable in the global options? It defaults to 500 seconds)
- Supports the `options` payload attribute so a module can be run with a single request
- Uses locks to prevent a module being executed multiple times with different options (causing race conditions)

The second point resolves #107. The last two points add support for stateful usage of the `POST /api/tasks/` endpoint.

### Request
```json5
POST http://localhost:5000/api/tasks/?sync
{
  "path": "recon/domains-hosts/hackertarget",
  "options": {
      "SOURCE": "google.com"
  }
}
```
### Response
```json5
{
    "summary": {
        "hosts": {
            "count": 501,
            "new": 0
        }
    },
    "data": {
        "hosts": [
            {
                "host": "google.com",
                "ip_address": "172.217.15.110",
                "region": null,
                "country": null,
                "latitude": null,
                "longitude": null,
                "notes": null,
                "module": "hackertarget"
            },
            ...
        ]
    }
}
```