### PR TITLE
Modify dockerfile and docker-compose to simplify start up steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.7-alpine
+FROM python:3.7-alpine AS recon-ng
 
 RUN mkdir -p /recon-ng
 
 WORKDIR /recon-ng
 
-ADD ./REQUIREMENTS /recon-ng/REQUIREMENTS
+COPY ./REQUIREMENTS /recon-ng/REQUIREMENTS
 
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev libxslt-dev &&\
     apk add --no-cache libxslt &&\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3.7'
 services:
 
     web:
-        build: .
+        build:
+            context: .
         image: recon-ng
         container_name: recon-ng
         ports:
@@ -27,6 +28,7 @@ services:
             - REDIS_URL=redis://redis:6379/0
         depends_on:
             - redis
+            - web
 
     redis:
         image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3.7'
 services:
 
     web:
-        build:
-            context: .
+        build: .
         image: recon-ng
         container_name: recon-ng
         ports:


### PR DESCRIPTION
By tagging the image on line 1 of the Dockerfile `AS recon-ng` we no longer need to build and tag it as a separate command prior to running `docker-compose up`

Change `ADD` to `COPY` as this is the preferred method on local files. `ADD` should be used for local extraction of tar files or to grab a resource from a remote source, as this is neither `COPY` will suffice.

Add `web` to the worker `depends_on`, this means that if the `recon-ng` image does not exist prior to running `docker-compose up` the web must have started (i.e. the `recon-ng` image is built before worker tries to use it).

