### PR TITLE
[Update] for running the container only by docker-compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: '3.7'
 services:
 
     web:
-        build: .
+        build:
+          context: .
+          dockerfile: Dockerfile
+          target: recon-ng
         image: recon-ng
         container_name: recon-ng
         ports:
@@ -18,6 +21,10 @@ services:
             - redis
 
     worker:
+        build:
+          context: .
+          dockerfile: Dockerfile
+          target: recon-ng
         image: recon-ng
         command: rq worker -u redis://redis:6379/0 recon-tasks
         volumes:


### PR DESCRIPTION
Previously to run the container you would have to build it first and then run docker-compose up.
Now you can just run it with docker-compose up.
Hopefully save some extra steps.