### PR TITLE
docs: fix simple typo, continous -> continuous

### DIFF
--- a/recon/core/web/exports.py
+++ b/recon/core/web/exports.py
@@ -30,7 +30,7 @@ def xmlify(rows):
     return Response(xml, mimetype='text/xml')
 
 def listify(rows):
-    '''Expects a list of dictionaries and returns a continous list of
+    '''Expects a list of dictionaries and returns a continuous list of
     values from all of the provided columns.'''
     columns = {}
     for row in rows:


### PR DESCRIPTION
There is a small typo in recon/core/web/exports.py.

Should read `continuous` rather than `continous`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md