### PR TITLE
Python 3.12: Migrate from deprecated imp to importlib

### DIFF
--- a/recon/core/framework.py
+++ b/recon/core/framework.py
@@ -165,6 +165,7 @@ class Framework(cmd.Cmd):
             sys.stdin = sys.__stdin__
             Framework._script = 0
             Framework._load = 0
+            print('')
             return
         if cmd is None:
             return self.default(line)


### PR DESCRIPTION
This PR migrates from `imp` to `importlib`.
The helper function followed https://docs.python.org/3/whatsnew/3.12.html#imp

This should make recon-ng work with Python 3.12